### PR TITLE
Added a message to screen when the "Saved Suggestions" list is empty

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -105,7 +105,11 @@ class _RandomWordsState extends State<RandomWords> {
             appBar: AppBar(
               title: const Text('Saved Suggestions'),
             ),
-            body: ListView(children: divided),
+            body: divided.isNotEmpty
+                ? ListView(children: divided)
+                : const Center(
+                    child: Text('Saved suggestions list is empty'),
+                  ),
           );
         },
       ),


### PR DESCRIPTION
### What?
Added a message to the screen when the "Saved Suggestions" list is empty
### Why?
The message shows that the page is not still loading and is not crashed
### How?
I used a ternary operator to display the Text widget instead of the ListView when the array with saved names 'divided' is empty

## Demo
Empty list:
![image](https://user-images.githubusercontent.com/57559975/134436550-c2a6a12c-0d50-4094-b4dd-654d1fd7e6fb.png)
List with saved items:
![image](https://user-images.githubusercontent.com/57559975/134437446-40077939-b60a-4231-b68a-a810b9769c63.png)

